### PR TITLE
Don't copy other block files (php, json) if they haven't changed since last run

### DIFF
--- a/tasks/blocks.js
+++ b/tasks/blocks.js
@@ -18,7 +18,7 @@ const webpackStream = require( 'webpack-stream' );
 const wpWebpackConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 // GulpWP
-const { c, handleStreamError, log, logFiles } = require( '../util' );
+const { c, changed, handleStreamError, log, logFiles } = require( '../util' );
 
 const blockAssets = [ 'script', 'style', 'editorScript', 'editorStyle', 'viewScript' ];
 
@@ -180,6 +180,7 @@ module.exports = {
 				gulp.src( src )
 					.pipe( handleStreamError( 'blocks' ) )
 					.pipe( filterOthers )
+					.pipe( changed( gulp.lastRun( blocks ) ) )
 					.pipe( logFiles( { task: 'blocks', title: 'copy:' } ) )
 					.pipe( gulp.dest( dest ) )
 			);


### PR DESCRIPTION
Prevents a double browsersync reload.