### PR TITLE
fix #23

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	},
 	"scripts": {},
 	"dependencies": {
+		"@martin-pettersson/wp-get-file-data": "^0.1.1",
 		"@wordpress/scripts": "^21.0.1",
 		"ansi-colors": "^4.1.1",
 		"autoprefixer": "^10.3.1",
@@ -82,8 +83,7 @@
 		"vinyl-named": "^1.1.0",
 		"vinyl-read": "^1.0.0",
 		"webpack-remove-empty-scripts": "^0.7.3",
-		"webpack-stream": "^7.0.0",
-		"wp-get-file-data": "^1.0.0"
+		"webpack-stream": "^7.0.0"
 	},
 	"devDependencies": {
 		"@wordpress/eslint-plugin": "^10.0.1",

--- a/tasks/translate.js
+++ b/tasks/translate.js
@@ -4,28 +4,24 @@
 
 // Node
 const { join } = require( 'path' );
-const { promisify } = require( 'util' );
 
 // External
-const fileData = promisify( require( 'wp-get-file-data' ) );
 const sort = require( 'gulp-sort' );
 const wpPot = require( 'gulp-wp-pot' );
 
 // Internal
-const { c, handleStreamError, log, logFiles } = require( '../util' );
+const { c, getFileData, handleStreamError, log, logFiles } = require( '../util' );
 
 module.exports = {
 	task: ( gulp, { src, dest }, registry ) => {
 		return function translate() {
 			const { plugin } = registry.config;
 			const metadataFile = plugin !== undefined ? plugin : 'style.css';
-			const projectType = plugin !== undefined ? 'Plugin' : 'Theme';
+			const packageName = plugin !== undefined ? 'Plugin Name' : 'Theme Name';
 
-			return fileData( metadataFile, {
-				package: `${ projectType } Name`,
-				domain: 'Text Domain',
-			} )
+			return getFileData( metadataFile )
 				.catch( ( err ) => {
+					console.log(err);
 					log.warn(
 						c.yellow(
 							'No metadata file found. Make sure you have a'
@@ -41,7 +37,8 @@ module.exports = {
 					);
 					return {};
 				} )
-				.then( ( { domain, package } ) => {
+				.then( ( data ) => {
+					const { ['Text Domain']: domain, [packageName]: package } = data;
 					// Add metadataFile to src array
 					if ( metadataFile ) {
 						if ( Array.isArray( src ) ) {
@@ -53,12 +50,12 @@ module.exports = {
 
 					if ( ! package ) {
 						log.warn(
-							c.cyan( `${ projectType } Name` ),
+							c.cyan( packageName ),
 							c.yellow( 'not found.' )
 						);
 					} else {
 						log.info(
-							`${ c.cyan( `${ projectType } Name` ) }:`,
+							`${ c.cyan( packageName ) }:`,
 							c.magenta( package )
 						);
 					}

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -3,15 +3,13 @@
  */
 
 // Node
-const { basename, dirname, extname, resolve } = require( 'path' );
-const { promisify } = require( 'util' );
+const { basename, dirname, extname } = require( 'path' );
 
 // External
-const fileData = promisify( require( 'wp-get-file-data' ) );
 const replace = require( 'gulp-replace' );
 
 // Internal
-const { c, getPackageJSON, handleStreamError, log } = require( '../util' );
+const { c, getFileData, getPackageJSON, handleStreamError, log } = require( '../util' );
 
 module.exports = {
 	task: ( gulp, { src }, registry ) => {
@@ -35,10 +33,8 @@ module.exports = {
 				filename === 'style.css' ||
 				extname( filename ).toLowerCase === '.php'
 			) {
-				return fileData( filePath, {
-					version: 'Version',
-				} ).then( ( { version } ) => {
-					return version;
+				return getFileData( filePath ).then( ( { Version } ) => {
+					return Version;
 				} );
 			}
 

--- a/util/index.js
+++ b/util/index.js
@@ -14,6 +14,7 @@ const {
 } = require( 'fs' );
 const { basename, dirname, join, parse, resolve } = require( 'path' );
 const { cwd } = require( 'process' );
+const { promisify } = require( 'util' );
 
 // External
 const c = require( 'ansi-colors' );
@@ -26,6 +27,7 @@ const plumber = require( 'gulp-plumber' );
 const through2 = require( 'through2' );
 const toAbsGlob = require( 'to-absolute-glob' );
 const Vinyl = require( 'vinyl' );
+const wpGetFileData = require( '@martin-pettersson/wp-get-file-data' );
 
 c.enabled = require( 'color-support' ).hasBasic;
 
@@ -143,6 +145,13 @@ const dependentsConfig = {
 for ( const ext of jsPostfixes ) {
 	dependentsConfig[ ext ] = jsDependentsConfig;
 }
+
+/**
+ * Get WP file header data.
+ *
+ * @returns {object} File header data
+ */
+const getFileData = promisify( wpGetFileData.getFileData );
 
 /**
  * Get the contents of package.json
@@ -329,6 +338,7 @@ module.exports = {
 	c,
 	changed,
 	dependentsConfig,
+	getFileData,
 	getPackageJSON,
 	getPluginFile,
 	handleStreamError,


### PR DESCRIPTION
- replaces wp-get-file-data with @martin-pettersson/wp-get-file-data because it recognizes file headers within a proper docblock, which is more likely to be the format of plugin headers
- include this lib as an export from utils, which promisifies it in one place for both the translate and version tasks