### PR TITLE
Fix relative paths for asset file output

### DIFF
--- a/util/index.js
+++ b/util/index.js
@@ -64,7 +64,8 @@ const assetFile = ( ignoreGlob = false ) => {
 		log.debug( 'asset file:', c.blue( path ) );
 		// Create php file with md5 hash as version.
 		const asset = new Vinyl( {
-			base,
+			cwd: file.cwd,
+			base: file.base, // Fix for gulp.dest() placing asset files in root instead of at relative path.
 			path,
 			contents,
 		} );


### PR DESCRIPTION
Use the original file's base for asset file generation for the relative path to match the original file and be output alongside it. Fixes #43.