### PR TITLE
Downgrade gulplog to working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"gulp-sort": "^2.0.0",
 		"gulp-wp-pot": "^2.5.0",
 		"gulp-zip": "^5.1.0",
-		"gulplog": "^2.0.1",
+		"gulplog": "^1.0.0",
 		"merge-stream": "^2.0.0",
 		"micromatch": "^4.0.5",
 		"node-sass-json-importer": "^4.3.0",


### PR DESCRIPTION
Not sure what changed in gulplog v2.0.0, but I can no longer get debug output (`-LLLL`) without reverting to v1.0.0.