### PR TITLE
Fix extra block.json copies in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 		"autoprefixer": "^10.4.14",
 		"browser-sync": "^2.29.1",
 		"color-support": "^1.1.3",
-		"copy-webpack-plugin": "^11.0.0",
 		"cross-spawn": "^7.0.3",
 		"deepmerge": "^4.3.1",
 		"del": "^6.1.1",
@@ -95,6 +94,7 @@
 		"prettier": "npm:wp-prettier@^2.8.5"
 	},
 	"peerDependencies": {
-		"webpack": "^5.68.0"
+		"webpack": "^5.68.0",
+		"copy-webpack-plugin": "^10.2.4"
 	}
 }

--- a/tasks/blocks.js
+++ b/tasks/blocks.js
@@ -3,7 +3,7 @@
  */
 
 // Node
-const { basename, dirname, extname, join } = require( 'path' );
+const { basename, dirname, extname, join, relative } = require( 'path' );
 
 // External
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
@@ -104,6 +104,7 @@ module.exports = {
 				},
 				plugins: [
 					new RemoveEmptyScriptsPlugin(),
+					// Remove the default CopyWebpackPlugin which interferes with our custom json and php handling.
 					...( wpWebpackConfig?.plugins || [] ).filter(
 						( plugin ) => ! ( plugin instanceof CopyWebpackPlugin )
 					),

--- a/tasks/blocks.js
+++ b/tasks/blocks.js
@@ -120,7 +120,11 @@ module.exports = {
 			 */
 			const streamBlockAssets = through2.obj(
 				function filterBlockAssetEntries( file, enc, cb ) {
-					log.debug( file.path );
+					log.info(
+						`${ c.cyan( 'blocks' ) } processing meta: ${ c.blue(
+							relative( file.cwd, file.path )
+						) }`
+					);
 					// Parse block.json for asset files.
 					const data = JSON.parse( file.contents.toString() );
 					if ( data ) {

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -3,6 +3,7 @@
  */
 
 // External
+const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const dedupe = require( 'gulp-dedupe' );
 const dependents = require( 'gulp-dependents' );
 const named = require( 'vinyl-named' );
@@ -33,6 +34,12 @@ module.exports = {
 						...includePaths,
 					],
 				},
+				plugins: [
+					// Remove the default CopyWebpackPlugin which will grab errant json and php files.
+					...( wpWebpackConfig?.plugins || [] ).filter(
+						( plugin ) => ! ( plugin instanceof CopyWebpackPlugin )
+					),
+				],
 				devtool: 'source-map',
 			};
 			// Remove config props that may interfere with webpackStream.

--- a/util/index.js
+++ b/util/index.js
@@ -12,7 +12,7 @@ const {
 	readFileSync,
 	readSync,
 } = require( 'fs' );
-const { basename, dirname, join, parse, resolve } = require( 'path' );
+const { basename, dirname, join, parse, resolve, relative } = require( 'path' );
 const { cwd } = require( 'process' );
 const { promisify } = require( 'util' );
 
@@ -45,7 +45,10 @@ const assetFile = ( ignoreGlob = false ) => {
 				ignoreGlob.map( ( g ) => toAbsGlob( g, { cwd: file.cwd } ) )
 			)
 		) {
-			log.debug( 'asset file: ignoring', c.blue( file.path ) );
+			log.debug(
+				'asset file: ignoring',
+				c.blue( relative( file.cwd, file.path ) )
+			);
 			return cb( null, file );
 		}
 
@@ -61,7 +64,7 @@ const assetFile = ( ignoreGlob = false ) => {
 		const contents = Buffer.from(
 			`<?php return array('version' => '${ hash }', 'dependencies' => array());`
 		);
-		log.debug( 'asset file:', c.blue( path ) );
+		log.debug( 'asset file:', c.blue( relative( file.cwd, path ) ) );
 		// Create php file with md5 hash as version.
 		const asset = new Vinyl( {
 			cwd: file.cwd,


### PR DESCRIPTION
This fixes #37: block.json getting copied into additional dist folders due to wp-scripts CopyWebpackPlugin.