### PR TITLE
fix js extensions config for gulp-dependents to include '.'

### DIFF
--- a/util/index.js
+++ b/util/index.js
@@ -149,7 +149,7 @@ const dependentsConfig = {
 	},
 };
 for ( const ext of jsPostfixes ) {
-	dependentsConfig[ ext ] = jsDependentsConfig;
+	dependentsConfig[ `.${ ext }` ] = jsDependentsConfig;
 }
 
 /**


### PR DESCRIPTION
fixes #49