### PR TITLE
Fix translate task error

### DIFF
--- a/tasks/translate.js
+++ b/tasks/translate.js
@@ -120,7 +120,7 @@ module.exports = {
 	config: {
 		src: [
 			'**/*.php',
-			'dist/**/*.{js,php}',
+			//'dist/**/*.js', // TODO: wp-pot must be run separately for JS.
 			'!node_modules/**/*',
 			'!**/*.asset.php',
 			'!src/**/*',

--- a/tasks/translate.js
+++ b/tasks/translate.js
@@ -86,7 +86,7 @@ module.exports = {
 
 					return gulp
 						.src( src )
-						.pipe( handleStreamError( 'styles' ) )
+						.pipe( handleStreamError( 'translate' ) )
 						.pipe( sort() )
 						.pipe(
 							// TODO: wpPot config options.

--- a/util/index.js
+++ b/util/index.js
@@ -218,9 +218,13 @@ const handleStreamError = ( task ) => {
 			// Format error message for console.
 			let consoleErr = err;
 			if ( err?.plugin && err?.name && err?.message ) {
-				consoleErr = `${ c.red( err.name ) } in plugin '${ c.cyan(
-					err.plugin
-				) }' (${ c.cyan( task ) })\n${ c.red( err.message ) }`;
+				consoleErr = `${ c.cyan( task ) }: ${ c.red(
+					err.name
+				) } in plugin '${ c.cyan( err.plugin ) }'\n${ c.red(
+					err.message
+				) }`;
+			} else if ( typeof err === 'string' ) {
+				consoleErr = `${ c.cyan( task ) }: ${ c.red( err ) }`;
 			}
 
 			// Log debug error to console.


### PR DESCRIPTION
Remove JS files from translate task src, since it wasn't parsing them anyways. Will need a separate feature to include JS file parsing.

Fixes #48